### PR TITLE
Add support for npm deprecations

### DIFF
--- a/src/clients/npm/models/registry.rs
+++ b/src/clients/npm/models/registry.rs
@@ -31,11 +31,17 @@ pub struct RegistryMetadataVersion {
     pub author: Option<RegistryMetadataHumanVariant>,
     #[serde(default)]
     pub maintainers: Vec<RegistryMetadataHumanVariant>,
+    #[serde(default)]
+    pub deprecated: Option<String>,
 }
 
 impl Versioned for RegistryMetadataVersion {
     fn raw_version_string(&self) -> String {
         self.version.to_string()
+    }
+
+    fn deprecated(&self) -> bool {
+        self.deprecated.is_some()
     }
 }
 

--- a/src/tools/npm/diagnostics.rs
+++ b/src/tools/npm/diagnostics.rs
@@ -81,7 +81,7 @@ pub async fn get_npm_diagnostics(
         return Ok(vec![Diagnostic {
             source: Some(String::from("NPM")),
             range: dep_version.range,
-            message: format!("Version `{version}` is deprecated: {deprecation_reason}",),
+            message: format!("Version `{version}` is deprecated: {deprecation_reason}"),
             severity: Some(DiagnosticSeverity::WARNING),
             tags: Some(vec![DiagnosticTag::DEPRECATED]),
             ..Default::default()

--- a/src/tools/npm/diagnostics.rs
+++ b/src/tools/npm/diagnostics.rs
@@ -45,12 +45,26 @@ pub async fn get_npm_diagnostics(
         }
     };
 
-    // Check if any version meeting the one specified exists
-    if !meta.versions.iter().any(|(_, v)| {
+    let mut has_versions = false;
+    let mut deprecation_reason = None;
+    for version in meta.versions.values().filter(|v| {
         v.version
             .parse_version()
             .is_ok_and(|v| version_req.matches(&v))
     }) {
+        has_versions = true;
+        let Some(reason) = version.deprecated.as_deref() else {
+            deprecation_reason = None;
+            break;
+        };
+
+        if deprecation_reason.is_none() {
+            deprecation_reason = Some(reason);
+        }
+    }
+
+    // Check if any version meeting the one specified exists
+    if !has_versions {
         return Ok(vec![Diagnostic {
             source: Some(String::from("NPM")),
             range: dep_version.range,
@@ -59,6 +73,17 @@ pub async fn get_npm_diagnostics(
                 dep.name().unquoted()
             ),
             severity: Some(DiagnosticSeverity::ERROR),
+            ..Default::default()
+        }]);
+    }
+
+    if let Some(deprecation_reason) = deprecation_reason {
+        return Ok(vec![Diagnostic {
+            source: Some(String::from("NPM")),
+            range: dep_version.range,
+            message: format!("Version `{version}` is deprecated: {deprecation_reason}",),
+            severity: Some(DiagnosticSeverity::WARNING),
+            tags: Some(vec![DiagnosticTag::DEPRECATED]),
             ..Default::default()
         }]);
     }

--- a/src/util/versions.rs
+++ b/src/util/versions.rs
@@ -180,6 +180,10 @@ pub trait Versioned {
         self.raw_version_string().trim().parse()
     }
 
+    fn deprecated(&self) -> bool {
+        false
+    }
+
     fn extract_latest_version_filtered<I, V, F>(
         &self,
         other_versions: I,
@@ -195,6 +199,7 @@ pub trait Versioned {
 
         let other_versions = other_versions
             .into_iter()
+            .filter(|v| !v.deprecated())
             .filter_map(|o| match o.parse_version() {
                 Ok(v) => Some((o, v)),
                 Err(_) => None,
@@ -260,6 +265,7 @@ pub trait Versioned {
 
         let mut potential_versions = potential_versions
             .into_iter()
+            .filter(|v| !v.deprecated())
             .filter_map(|item| {
                 if this_version_raw.is_empty() {
                     return Some(item);


### PR DESCRIPTION
Adds support for deprecations, currently specifically for npm. Deprecated versions won't be included as completion candidates and candidates for the latest version.

An example warning about a deprecated version looks like this:
![warning about @eslint/js@10.0.0 being deprecated](https://github.com/user-attachments/assets/4de27059-0c00-453d-8b39-de26516ec971)
